### PR TITLE
Added "replace" option to add()

### DIFF
--- a/pinboard.py
+++ b/pinboard.py
@@ -313,6 +313,15 @@ class PinboardAccount(UserDict):
         self.__postschanged = 0
         return posts
 
+    def suggest(self, url):
+        query = {'url': url}
+        tags = self.__request("%s/posts/suggest?%s" % (PINBOARD_API, urllib.urlencode(query)))
+
+        popular = [t.firstChild.data for t in tags.getElementsByTagName('popular')]
+        recommended = [t.firstChild.data for t in tags.getElementsByTagName('recommended')]
+ 
+        return {'popular': popular, 'recommended': recommended}
+
     def tags(self):
         """Return a dictionary of tags with the number of posts in each one"""
         tagsxml = self.__request("%s/tags/get?" % \

--- a/pinboard.py
+++ b/pinboard.py
@@ -391,12 +391,13 @@ class PinboardAccount(UserDict):
 
     # Methods to modify pinboard.in content
 
-    def add(self, url, description, extended="", tags=(), date="", toread="no"):
+    def add(self, url, description, extended="", tags=(), date="", toread="no", replace="no"):
         """Add a new post to pinboard.in"""
         query = {}
         query["url"] = url
         query ["description"] = description
         query["toread"] = toread
+        query["replace"] = replace
         if extended:
             query["extended"] = extended
         if tags and (isinstance(tags, TupleType) or isinstance(tags, ListType)):


### PR DESCRIPTION
Pinboard supports updating a bookmark in place, but I didn't see that functionality in pinboard.py. <code>replace</code> defaults to <code>"no"</code> for backwards compatibility.
