### PR TITLE
Private bookmarks addition supported

### DIFF
--- a/pinboard.py
+++ b/pinboard.py
@@ -400,13 +400,14 @@ class PinboardAccount(UserDict):
 
     # Methods to modify pinboard.in content
 
-    def add(self, url, description, extended="", tags=(), date="", toread="no", replace="no"):
+    def add(self, url, description, extended="", tags=(), date="", toread="no", replace="no", shared="yes"):
         """Add a new post to pinboard.in"""
         query = {}
         query["url"] = url
         query ["description"] = description
         query["toread"] = toread
         query["replace"] = replace
+        query["shared"] = shared
         if extended:
             query["extended"] = extended
         if tags and (isinstance(tags, TupleType) or isinstance(tags, ListType)):


### PR DESCRIPTION
According to API documentation, [`posts/add`](http://pinboard.in/api#posts_add) method has **shared** parameter which could make bookmark public or private. This patch adds this optional parameter to `add()` function. Default value is Yes, so there will be no any affect to the dependent code.
